### PR TITLE
Allow "reversible" to proliferate through settings and configs.

### DIFF
--- a/pgclone/management/commands/pgclone.py
+++ b/pgclone/management/commands/pgclone.py
@@ -152,6 +152,7 @@ class RestoreCommand(BaseSubcommand):
         parser.add_argument(
             "-r",
             "--reversible",
+            default=None,  # Use None so that configs/settings can be used as defaults
             action="store_true",
             help="Keep current and previous database copies available for reversion.",
         )


### PR DESCRIPTION
The ``pgclone restore`` command was setting ``reversible`` to
``False``, negating settings or configs that overrode it. This
has been fixed.

Type: bug