### PR TITLE
Restore command properly overrides storage location

### DIFF
--- a/pgclone/management/commands/pgclone.py
+++ b/pgclone/management/commands/pgclone.py
@@ -129,10 +129,10 @@ class DumpCommand(BaseSubcommand):
         dump_cmd.dump(
             exclude=options["exclude"],
             pre_dump_hooks=options["pre_dump_hooks"],
-            config=options["config"],
             instance=options["instance"],
             database=options["database"],
             storage_location=options["storage_location"],
+            config=options["config"],
         )
 
 
@@ -176,9 +176,10 @@ class RestoreCommand(BaseSubcommand):
         restore_cmd.restore(
             dump_key=options["dump_key"],
             pre_swap_hooks=options["pre_swap_hooks"],
-            config=options["config"],
             reversible=options["reversible"],
             database=options["database"],
+            storage_location=options["storage_location"],
+            config=options["config"],
         )
 
 

--- a/pgclone/restore_cmd.py
+++ b/pgclone/restore_cmd.py
@@ -88,8 +88,8 @@ def _remote_restore(dump_key, *, temp_db, using, storage_location):
     # assume it is the latest dump of a database name and get the latest
     # dump key
     if not dump_key.endswith(".dump"):
-        sorted_dumps = sorted(ls_cmd.ls(dump_key=dump_key))
-        found_dump_key = sorted_dumps[-1] if sorted_dumps else None
+        dump_keys = ls_cmd.ls(dump_key=dump_key, storage_location=storage_location)
+        found_dump_key = dump_keys[0] if dump_keys else None
 
         if not found_dump_key:
             raise exceptions.RuntimeError(


### PR DESCRIPTION
The restore command now properly passes through custom storage locations from the
command line.

Type: bug