### PR TITLE
Add ability to specify endpoint url

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -108,6 +108,33 @@ For example:
 
 **Default**: ``{}``
 
+PGCLONE_S3_ENDPOINT_URL
+-----------------------
+
+The S3 endpoint url to send requests to if using a non-standard AWS endpoint or
+an S3 service other than AWS (such as DigitalOcean Spaces or self-hosting an
+endpoint directly within your private VPC). Only applicable when using the S3
+storage backend.
+
+For example:
+
+.. code-block:: python
+
+    PGCLONE_S3_ENDPOINT_URL = "https://endpoint.example.com"
+
+If using DigitalOcean Spaces, be sure to set ``PGCLONE_S3_ENDPOINT_URL`` and the
+storage location appropriately. For example, if the name of your Space is
+"my-backup-bucket" in the DigitalOcean SFO2 region, and the resulting endpoint is
+"https://my-backup-bucket.sfo2.digitaloceanspaces.com", then the following example
+settings would work (note we removed the Space's name from the endpoint url):
+
+.. code-block:: python
+
+    PGCLONE_S3_ENDPOINT_URL = "https://sfo2.digitaloceanspaces.com"
+    PGCLONE_STORAGE_LOCATION = "s3://my-backup-bucket/"
+
+**Default**: ``None``
+
 PGCLONE_STORAGE_LOCATION
 ------------------------
 

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -47,3 +47,13 @@ Here we override the AWS credentials and region:
 
 See `this guide <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html>`__
 for all environment variables that can be used with the AWS CLI.
+
+If using a non-standard AWS endpoint url or a non-AWS S3 provider, the endpoint url must be
+specified. Unfortunately, AWS CLI does not provide an environmental variable for this purpose.
+Instead, use the ``settings.PGCLONE_S3_ENDPOINT_URL`` setting, which will override the AWS CLI
+commands with the ``--endpoint-url`` option. ``AWS_ACCESS_KEY_ID`` and
+``AWS_SECRET_ACCESS_KEY`` must still be specified in ``settings.PGCLONE_S3_CONFIG``.
+
+.. code-block:: python
+
+    PGCLONE_S3_ENDPOINT_URL = "https://endpoint.example.com"

--- a/pgclone/settings.py
+++ b/pgclone/settings.py
@@ -11,6 +11,10 @@ def s3_config():
     return getattr(settings, "PGCLONE_S3_CONFIG", {})
 
 
+def s3_endpoint_url():
+    return getattr(settings, "PGCLONE_S3_ENDPOINT_URL", None)
+
+
 def storage_location():
     location = getattr(settings, "PGCLONE_STORAGE_LOCATION", ".pgclone")
     if not location.endswith("/"):  # pragma: no cover

--- a/pgclone/tests/test_storage.py
+++ b/pgclone/tests/test_storage.py
@@ -33,3 +33,21 @@ def test_s3_pg_dump():
 
 def test_s3_pg_restore():
     assert storage.S3("bucket").pg_restore("file_path") == "aws s3 cp file_path - |"
+
+
+def test_s3_pg_dump_with_endpoint_url(settings):
+    settings.PGCLONE_S3_ENDPOINT_URL = "https://endpoint.example.com"
+    assert (
+        storage.S3("bucket").pg_dump("file_path")
+        == "| aws s3 cp - file_path --endpoint-url https://endpoint.example.com"
+    )
+    delattr(settings, "PGCLONE_S3_ENDPOINT_URL")
+
+
+def test_s3_pg_restore_with_endpoint_url(settings):
+    settings.PGCLONE_S3_ENDPOINT_URL = "https://endpoint.example.com"
+    assert (
+        storage.S3("bucket").pg_restore("file_path")
+        == "aws s3 cp file_path - --endpoint-url https://endpoint.example.com |"
+    )
+    delattr(settings, "PGCLONE_S3_ENDPOINT_URL")


### PR DESCRIPTION
Adds capability to specify the S3 endpoint url to send requests to if using a non-standard AWS endpoint or an S3 service other than AWS (such as DigitalOcean Spaces or self-hosting an endpoint directly within your private VPC). Only applicable when using the S3 storage backend.

Type: trivial