### PR TITLE
Add ``pgclone copy`` command

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -8,15 +8,19 @@ Here we cover some of the basics of ``django-pgclone`` to make it easier to unde
 Core features
 -------------
 
-``django-pgclone`` has three primary commands:
+``django-pgclone`` has four primary commands:
 
 1. ``python manage.py pgclone ls``: Lists dumps.
 2. ``python manage.py pgclone dump``: Dump a database.
 3. ``python manage.py pgclone restore``: Restore a database.
+4. ``python manage.py pgclone copy``: Make a local copy of a database.
 
 The ``dump`` and ``restore`` commands wrap `pg_dump <https://www.postgresql.org/docs/current/app-pgdump.html>`__
 and `pg_restore <https://www.postgresql.org/docs/current/app-pgrestore.html>`__. Dumps and restores are compressed
 and streamed to and from a storage location. File names are visible with the ``ls`` command.
+
+``restore`` can restore local databases, such as local copies created during ``pgclone restore --reversible``
+or with ``pgclone copy``.
 
 Users can write :ref:`Hooks <hooks>` for dumping and restoring. For example:
 
@@ -59,6 +63,9 @@ following meaning:
   See :ref:`configurations` for more information on configurations.
 
 * **timestamp**: The time at which the dump happened.
+
+Local database copies have a special dump key prefixed with the ``:`` symbol. These can be listed
+with ``pgclone ls --local`` and passed as the dump key to ``pgclone restore``.
 
 Default values for command options
 ----------------------------------

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -57,6 +57,10 @@ Dump the database. Dump names are in the format of ``<instance>/<database>/<conf
     When doing a dump with ``-e`` or ``--pre-dump-hook`` and ``-c``, a config name of "none" will be
     used in the dump key since these parameters can alter the dump.
 
+.. tip::
+
+    Set ``settings.PGCLONE_ALLOW_DUMP`` to ``False`` to disable dumps.
+
 restore
 -------
 
@@ -67,7 +71,9 @@ upon completion.
 
 dump_key
     A dump key or prefix of a dump key. If a prefix is provided, the most recent
-    dump key matching it will be used.
+    dump key matching it will be used. A dump key with ``:`` at the beginning
+    means that we are restoring a local database, such as one created when restoring
+    with the ``--reversible`` option.
 
 --pre-swap-hook  Execute a management command on the restored database
                  before it is swapped to the primary. Can be used multiple times.
@@ -79,3 +85,31 @@ dump_key
 .. tip::
 
     Set ``settings.PGCLONE_ALLOW_RESTORE`` to ``False`` to disable restores.
+
+copy
+----
+
+Make a local copy of the database using ``CREATE DATABASE <target> TEMPLATE <source>``.
+By default, the default database is copied to the same name created when
+performing a reversible restore, meaning one can do ``pgclone copy`` followed by
+``pgclone restore :current`` to restore it.
+
+**Options**
+
+dump_key
+    A dump key to identify the local copy. Must start with ``:`` and only consist
+    of valid database name characters.
+
+-d, --database  Copy this database.
+-c, --config  Use this configuration to supply default option values.
+
+.. danger::
+
+    Running ``pgclone copy`` will take out an exclusive access lock on the source database,
+    meaning all reads and writes to the database will be blocked until the operation
+    is finished. Only use this command in non-production environments for fast
+    copying and restores.
+
+.. tip::
+
+    Set ``settings.PGCLONE_ALLOW_COPY`` to ``False`` to disable copies.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import os
-import subprocess
 import sys
 
 import django

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -16,6 +16,15 @@ If storage or lengthier restore times are not a concern, you can also
 configure :ref:`Reversible Restores <reversible>` to happen by default, allowing you to
 restore back to the previous version if it was a mistake.
 
+What other ways can I protect accidental incorrect usage?
+---------------------------------------------------------
+
+All core commands (``dump``, ``restore``, and ``copy``) have associated ``PGCLONE_ALLOW_*``
+options. In a production environment, setting
+``settings.PGCLONE_ALLOW_RESTORE`` and ``settings.PGCLONE_ALLOW_COPY`` to ``False`` are good ideas. If you
+have sensitive data that should not be dumped to outside storage, set
+``settings.PGCLONE_ALLOW_DUMP`` to ``False``.
+
 ``pg_restore`` shows errors but succeeded. What happened?
 ---------------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ following sections for more information:
 * :ref:`hooks` - Run management command hooks during
   dumping or restoring.
 * :ref:`reversible` - Create restores that can be quickly reverted.
+* :ref:`local_copies` - Create local copies that can be quickly reverted.
 * :ref:`configurations` - For re-using command parameters.
 * :ref:`settings` - All settings.
 * :ref:`rds` - Additional notes on Amazon RDS configuration.

--- a/docs/local_copies.rst
+++ b/docs/local_copies.rst
@@ -1,0 +1,41 @@
+.. _local_copies:
+
+Local Copies
+============
+
+Some database dump and restore flows can be facilitated by making local copies
+so that they can be quickly restored later (as opposed to a full restore with
+``pg_restore``). This can be accomplished with the ``pgclone copy`` command.
+
+The ``pgclone copy`` command will copy the current database to a target database
+name using ``CREATE DATABASE <source> TEMPLATE <target>``. By default, it uses
+the same database name that ``pgclone restore --reversible`` uses when creating
+the restore point of the current database.
+
+In other words, you can do the following to create a copy of the database locally::
+
+    python manage.py pgclone copy
+
+And then you can restore it with the following::
+
+    python manage.py pgclone restore :current
+
+.. tip::
+
+    By default, ``pgclone restore`` will delete the special ``:current`` database
+    unless ``--reversible`` is supplied. Use a custom copy name as shown below to
+    avoid this.
+
+To create named local copies, pass in a key that begins with ``:``. For example::
+
+    python manage.py pgclone copy :my_backup
+
+You can later restore this backup with::
+
+    python manage.py pgclone restore :my_backup
+
+.. danger::
+
+    Calling ``pgclone copy`` will take out an exclusive access lock on the default
+    database when copying it, preventing all activity until the copy is done. Use
+    with caution, especially when running this in a production environment.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -16,6 +16,16 @@ PGCLONE_ALLOW_RESTORE
 
 If ``False``, running any restore results in an error.
 
+PGCLONE_ALLOW_DUMP
+------------------
+
+If ``False``, running any dump results in an error.
+
+PGCLONE_ALLOW_COPY
+------------------
+
+If ``False``, running any copy results in an error.
+
 **Default** ``True``
 
 PGCLONE_CONFIGS

--- a/docs/toc.rst
+++ b/docs/toc.rst
@@ -11,6 +11,7 @@ Table of Contents
    storage
    hooks
    reversible
+   local_copies
    configurations
    settings
    rds

--- a/pgclone/copy_cmd.py
+++ b/pgclone/copy_cmd.py
@@ -1,0 +1,69 @@
+from pgclone import db, exceptions, logging, options, settings
+
+
+def _copy(*, dump_key, database):
+    """
+    Copy implementation
+    """
+    if not settings.allow_copy():  # pragma: no cover
+        raise exceptions.RuntimeError("Copy not allowed.")
+
+    source_db = db.conf(using=database)
+
+    if not dump_key or dump_key == ":current":
+        dump_key = ":current"
+        target_db_name = f'{source_db["NAME"]}__curr'
+    elif dump_key == ":previous":
+        target_db_name = f'{source_db["NAME"]}__prev'
+    else:
+        if not dump_key.startswith(":"):  # pragma: no cover
+            raise RuntimeError('Copy target must start with ":"')
+
+        target_db_name = dump_key[1:]
+
+    target_db = db.make(target_db_name, using=database, check=False)
+
+    if source_db == target_db:  # pragma: no cover
+        raise exceptions.RuntimeError("Target database cannot be the same as source database.")
+
+    logging.success_msg("Creating copy")
+    db.drop(target_db, using=database)
+    copy_db_sql = f"""
+        CREATE DATABASE "{target_db['NAME']}"
+            WITH TEMPLATE
+        "{source_db['NAME']}"
+    """
+    db.kill_connections(source_db, using=database)
+    db.psql(copy_db_sql, using=database)
+
+    logging.success_msg(f'Successfully copied database "{database}" to "{dump_key}"')
+
+    return dump_key
+
+
+def copy(dump_key=None, *, database=None, config=None):
+    """
+    Copies a database using ``CREATE DATABASE <dump_key> TEMPLATE <database>``.
+
+    Note that we use dump keys with the same syntax that ``dump`` and ``restore``
+    commands take. Since ``copy`` only works with local database copies, this
+    means the dump keys are always the database name prefixed with ``:``.
+
+    Args:
+        dump_key (str, default=None): A name to use for the copy. Must be prefixed
+            with ``:`` and only consist of valid database name characters.
+            If ``None``, ``:{database}__curr`` is used as the key.
+        database (str, default=None): The database to copy.
+        config (str, default=None): The configuration name
+            from ``settings.PGCLONE_CONFIGS``.
+
+    Returns:
+        str: The dump key that was copied.
+    """
+    opts = options.get(
+        dump_key=dump_key,
+        config=config,
+        database=database,
+    )
+
+    return _copy(dump_key=opts.dump_key, database=opts.database)

--- a/pgclone/dump_cmd.py
+++ b/pgclone/dump_cmd.py
@@ -4,7 +4,7 @@ import re
 
 from django.apps import apps
 
-from pgclone import db, logging, options, run, storage
+from pgclone import db, exceptions, logging, options, run, settings, storage
 
 
 DT_FORMAT = "%Y-%m-%d-%H-%M-%S-%f"
@@ -21,6 +21,9 @@ def _dump_key(*, instance, database, config):
 
 def _dump(*, exclude, config, pre_dump_hooks, instance, database, storage_location):
     """Dump implementation"""
+    if not settings.allow_restore():  # pragma: no cover
+        raise exceptions.RuntimeError("Dump not allowed.")
+
     storage_client = storage.client(storage_location)
     dump_db = db.conf(using=database)
 

--- a/pgclone/dump_cmd.py
+++ b/pgclone/dump_cmd.py
@@ -21,7 +21,7 @@ def _dump_key(*, instance, database, config):
 
 def _dump(*, exclude, config, pre_dump_hooks, instance, database, storage_location):
     """Dump implementation"""
-    if not settings.allow_restore():  # pragma: no cover
+    if not settings.allow_dump():  # pragma: no cover
         raise exceptions.RuntimeError("Dump not allowed.")
 
     storage_client = storage.client(storage_location)

--- a/pgclone/management/commands/pgclone.py
+++ b/pgclone/management/commands/pgclone.py
@@ -2,7 +2,7 @@ import sys
 
 from django.core.management.base import BaseCommand
 
-from pgclone import dump_cmd, exceptions, logging, ls_cmd, restore_cmd
+from pgclone import copy_cmd, dump_cmd, exceptions, logging, ls_cmd, restore_cmd
 
 
 class Subcommands(BaseCommand):
@@ -183,9 +183,32 @@ class RestoreCommand(BaseSubcommand):
         )
 
 
+class CopyCommand(BaseSubcommand):
+    def add_arguments(self, parser):
+        parser.add_argument("dump_key", nargs="?", help="The local dump key to copy to.")
+        parser.add_argument(
+            "-d",
+            "--database",
+            help="Restore to this database.",
+        )
+        parser.add_argument(
+            "-c",
+            "--config",
+            help="Use this configuration to supply default option values.",
+        )
+
+    def subhandle(self, *args, **options):
+        copy_cmd.copy(
+            dump_key=options["dump_key"],
+            database=options["database"],
+            config=options["config"],
+        )
+
+
 class Command(Subcommands):
     subcommands = {
         "ls": LsCommand,
         "dump": DumpCommand,
         "restore": RestoreCommand,
+        "copy": CopyCommand,
     }

--- a/pgclone/run.py
+++ b/pgclone/run.py
@@ -5,7 +5,7 @@ import subprocess
 
 from django.core.management import call_command
 
-from pgclone import db, exceptions, logging
+from pgclone import exceptions, logging
 
 
 def shell(cmd, ignore_errors=False, env=None):
@@ -51,12 +51,3 @@ def management(cmd, *cmd_args, **cmd_kwargs):
         raise
     else:
         logger.info(output.getvalue())
-
-
-def psql(sql, *, using, ignore_errors=False):
-    """Runs psql -c with properly formatted SQL"""
-    db_url = db.url(db.conn(using=using))
-
-    # Format special SQL characters
-    sql = sql.replace("$", "\\$").replace("\n", " ").replace('"', '\\"').strip()
-    return shell(f'psql {db_url} -P pager=off -c "{sql};"', ignore_errors=ignore_errors)

--- a/pgclone/settings.py
+++ b/pgclone/settings.py
@@ -30,6 +30,14 @@ def allow_restore():
     return getattr(settings, "PGCLONE_ALLOW_RESTORE", True)
 
 
+def allow_dump():
+    return getattr(settings, "PGCLONE_ALLOW_DUMP", True)
+
+
+def allow_copy():
+    return getattr(settings, "PGCLONE_ALLOW_COPY", True)
+
+
 def configs():
     return getattr(settings, "PGCLONE_CONFIGS", {})
 

--- a/pgclone/tests/test_storage.py
+++ b/pgclone/tests/test_storage.py
@@ -41,7 +41,6 @@ def test_s3_pg_dump_with_endpoint_url(settings):
         storage.S3("bucket").pg_dump("file_path")
         == "| aws s3 cp - file_path --endpoint-url https://endpoint.example.com"
     )
-    delattr(settings, "PGCLONE_S3_ENDPOINT_URL")
 
 
 def test_s3_pg_restore_with_endpoint_url(settings):
@@ -50,4 +49,3 @@ def test_s3_pg_restore_with_endpoint_url(settings):
         storage.S3("bucket").pg_restore("file_path")
         == "aws s3 cp file_path - --endpoint-url https://endpoint.example.com |"
     )
-    delattr(settings, "PGCLONE_S3_ENDPOINT_URL")


### PR DESCRIPTION
The ``pgclone copy`` command is a shortcut for running ``CREATE DATABASE <target> TEMPLATE <source>``
for doing quick copies. This command complements local ``pgclone restore`` commands.

For example, copy the current database with ``pgclone copy``, and quickly restore it with
``pgclone restore :current``. Use a custom name with ``pgclone copy :custom_name`` and restore it
with ``pgclone restore :custom_name``.

Note that this command takes out an exclusive lock on the source database, meaning it should not be
executed in production environments.