### PR TITLE
Support overriding Postgres statement timeouts

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -169,3 +169,21 @@ This helps preserve backwards compatibility with version 1. Note that
 keys.
 
 **Default** ``True``
+
+PGCLONE_STATEMENT_TIMEOUT
+-------------------------
+
+The ``statement_timeout`` Postgres setting to use when running core ``pgclone``
+commands via ``psql``. For example, the statement timeout will apply to
+any ``CREATE DATABASE``, ``ALTER DATABASE``, or ``DROP DATABASE`` statements,
+along with statements that terminate blocking queries.
+
+**Default** ``None``
+
+PGCLONE_LOCK_TIMEOUT
+--------------------
+
+The ``lock_timeout`` Postgres setting to use when running core ``pgclone``
+commands via ``psql``. Similar to ``PGCLONE_STATEMENT_TIMEOUT``.
+
+**Default** ``None``

--- a/pgclone/copy_cmd.py
+++ b/pgclone/copy_cmd.py
@@ -28,11 +28,7 @@ def _copy(*, dump_key, database):
 
     logging.success_msg("Creating copy")
     db.drop(target_db, using=database)
-    copy_db_sql = f"""
-        CREATE DATABASE "{target_db['NAME']}"
-            WITH TEMPLATE
-        "{source_db['NAME']}"
-    """
+    copy_db_sql = f'CREATE DATABASE "{target_db["NAME"]}" WITH TEMPLATE "{source_db["NAME"]}"'
     db.kill_connections(source_db, using=database)
     db.psql(copy_db_sql, using=database)
 

--- a/pgclone/restore_cmd.py
+++ b/pgclone/restore_cmd.py
@@ -150,11 +150,9 @@ def _restore(*, dump_key, pre_swap_hooks, config, reversible, database, storage_
     if reversible and local_restore_db != curr_db:
         logging.success_msg("Creating snapshot for reversible restore")
         db.drop(curr_db, using=database)
-        create_current_db_sql = f"""
-            CREATE DATABASE "{curr_db['NAME']}"
-             WITH TEMPLATE
-            "{temp_db['NAME']}"
-        """
+        create_current_db_sql = (
+            f'CREATE DATABASE "{curr_db["NAME"]}" WITH TEMPLATE "{temp_db["NAME"]}"'
+        )
         db.psql(create_current_db_sql, using=database)
 
     # pre-swap hook step
@@ -167,19 +165,13 @@ def _restore(*, dump_key, pre_swap_hooks, config, reversible, database, storage_
     logging.success_msg("Swapping the restored copy with the primary database")
     db.drop(prev_db, using=database)
     db.kill_connections(restore_db, using=database)
-    alter_db_sql = f"""
-        ALTER DATABASE "{restore_db['NAME']}" RENAME TO
-        "{prev_db['NAME']}"
-    """
+    alter_db_sql = f'ALTER DATABASE "{restore_db["NAME"]}" RENAME TO "{prev_db["NAME"]}"'
     # There's a scenario where the default DB may not exist before running
     # this, so just ignore errors on this command
     db.psql(alter_db_sql, ignore_errors=True, using=database)
 
     db.kill_connections(temp_db, using=database)
-    rename_sql = f"""
-        ALTER DATABASE "{temp_db["NAME"]}"
-        RENAME TO "{restore_db["NAME"]}"
-    """
+    rename_sql = f'ALTER DATABASE "{temp_db["NAME"]}" RENAME TO "{restore_db["NAME"]}"'
     db.psql(rename_sql, using=database)
 
     if not reversible:

--- a/pgclone/settings.py
+++ b/pgclone/settings.py
@@ -7,6 +7,14 @@ from django.db import DEFAULT_DB_ALIAS
 from pgclone import exceptions
 
 
+def statement_timeout():
+    return getattr(settings, "PGCLONE_STATEMENT_TIMEOUT", None)
+
+
+def lock_timeout():
+    return getattr(settings, "PGCLONE_LOCK_TIMEOUT", None)
+
+
 def s3_config():
     return getattr(settings, "PGCLONE_S3_CONFIG", {})
 

--- a/pgclone/tests/test_db.py
+++ b/pgclone/tests/test_db.py
@@ -1,0 +1,25 @@
+import pytest
+
+from pgclone import db
+
+
+@pytest.mark.parametrize(
+    "lock_timeout, statement_timeout, sql, expected_sql",
+    [
+        (None, None, "COMMAND", "COMMAND;"),
+        (1, None, " COMMAND; ", "SET lock_timeout = 1;\nCOMMAND;"),
+        (1, 2, " COMMAND; ", "SET lock_timeout = 1;\nSET statement_timeout = 2;\nCOMMAND;"),
+        (None, 2, " COMMAND; ", "SET statement_timeout = 2;\nCOMMAND;"),
+        (
+            None,
+            None,
+            "    COMMAND\n      INDENTED\n      INDENTED; ",
+            "COMMAND\n  INDENTED\n  INDENTED;",
+        ),
+    ],
+)
+def test_fmt_psql_sql(settings, lock_timeout, statement_timeout, sql, expected_sql):
+    """Tests variations of the db._fmt_psql_sql command"""
+    settings.PGCLONE_STATEMENT_TIMEOUT = statement_timeout
+    settings.PGCLONE_LOCK_TIMEOUT = lock_timeout
+    assert db._fmt_psql_sql(sql) == expected_sql


### PR DESCRIPTION
Use ``settings.PGCLONE_STATEMENT_TIMEOUT`` to override Postgres's ``statement_timeout`` setting when running core ``pgclone`` SQL operations such as ``CREATE DATABASE``.

You can also use ``settings.PGCLONE_LOCK_TIMEOUT`` to override Postgres's ``lock_timeout`` setting.

Type: feature