### PR TITLE
Changed behavior of reversible restores and local copies

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -65,7 +65,12 @@ restore
 -------
 
 Restore the database. Restores happen in a temporary database that is swapped into the main one
-upon completion.
+upon completion after hooks have finished. One can restore both dumps or local databases created
+via ``pgclone copy`` or as a result of using the ``--reversible`` option.
+
+Reversible restores keep around copies of the database before and after the dump was restored.
+You can quickly revert to these copies with ``pgclone restore :pre`` or
+``pgclone restore :post``. Read more about reversible restores :ref:`here <reversible>`.
 
 **Options**
 
@@ -77,7 +82,8 @@ dump_key
 
 --pre-swap-hook  Execute a management command on the restored database
                  before it is swapped to the primary. Can be used multiple times.
--r, --reversible  Keep current and previous database copies available for reversion.
+-r, --reversible  Keep local copies of before and after the restore happened. This only applies
+                  to restoring dumps and has no effect when restoring local copies.
 -d, --database  Restore to this database.
 -s, --storage-location  Restore from this storage location.
 -c, --config  Use this configuration to supply default option values.
@@ -90,15 +96,15 @@ copy
 ----
 
 Make a local copy of the database using ``CREATE DATABASE <target> TEMPLATE <source>``.
-By default, the default database is copied to the same name created when
-performing a reversible restore, meaning one can do ``pgclone copy`` followed by
-``pgclone restore :current`` to restore it.
+For example, ``pgclone copy :my_backup`` makes a copy that can be restored with
+``pgclone restore :my_backup``.
 
 **Options**
 
 dump_key
-    A dump key to identify the local copy. Must start with ``:`` and only consist
-    of valid database name characters.
+    The target database in the format of a local dump key. In other words, the local database name
+    prefixed with ``:``. The reserved names for reversible restores
+    (``:pre`` and ``:post``) cannot be used.
 
 -d, --database  Copy this database.
 -c, --config  Use this configuration to supply default option values.

--- a/docs/local_copies.rst
+++ b/docs/local_copies.rst
@@ -8,34 +8,25 @@ so that they can be quickly restored later (as opposed to a full restore with
 ``pg_restore``). This can be accomplished with the ``pgclone copy`` command.
 
 The ``pgclone copy`` command will copy the current database to a target database
-name using ``CREATE DATABASE <source> TEMPLATE <target>``. By default, it uses
-the same database name that ``pgclone restore --reversible`` uses when creating
-the restore point of the current database.
+name using ``CREATE DATABASE <source> TEMPLATE <target>``. The command takes
+a local dump key, which is just the database name prefixed with ``:``.
 
-In other words, you can do the following to create a copy of the database locally::
-
-    python manage.py pgclone copy
-
-And then you can restore it with the following::
-
-    python manage.py pgclone restore :current
-
-.. tip::
-
-    By default, ``pgclone restore`` will delete the special ``:current`` database
-    unless ``--reversible`` is supplied. Use a custom copy name as shown below to
-    avoid this.
-
-To create named local copies, pass in a key that begins with ``:``. For example::
+In other words, you can do the following to copy your default database to another
+database called ``my_backup``::
 
     python manage.py pgclone copy :my_backup
 
-You can later restore this backup with::
+And then you can restore it with the following::
 
     python manage.py pgclone restore :my_backup
+
+.. note::
+
+    You cannot use ``:pre`` or ``:post`` as the target database
+    name. These are reserved for reversible restores.
 
 .. danger::
 
     Calling ``pgclone copy`` will take out an exclusive access lock on the default
     database when copying it, preventing all activity until the copy is done. Use
-    with caution, especially when running this in a production environment.
+    with caution, and never run this in a production environment.

--- a/docs/reversible.rst
+++ b/docs/reversible.rst
@@ -4,26 +4,27 @@ Reversible Restores
 ===================
 
 The ``--reversible`` option of ``manage.py pgclone restore`` keeps
-the copy of the database after the restore (i.e. the "current" database)
-and the copy of the database before the restore (i.e. the "previous" database).
+the copy of the database before the restore (i.e. the "pre" restore point)
+and after the restore (i.e. the "post" restore point).
 
-The current database can be restored with::
+When using this option, you can then quickly revert to the point after
+the most recent restore with::
 
-    python manage.py pgclone restore :current
+    python manage.py pgclone restore :post
 
-The previous database can be restored with::
+Or to the point before the most recent restore with::
 
-    python manage.py pgclone restore :previous
+    python manage.py pgclone restore :pre
 
 Keep the following in mind when using ``--reversible``:
 
 1. Restores take longer because an additional copy is made.
-2. If you restore ``:current``, ``--reversible``
-   must be used if you want to restore ``:current`` again.
-   Otherwise those database copies will be dropped.
-3. If you restore ``:previous`` with ``--reversible``,
-   ``:current`` will now refer to the original ``:previous``
-   and vice versa.
+2. If you restore to the ``:pre`` or ``:post`` points,
+   the ``--reversible`` option has no effect. It only has
+   an effect when restoring database dumps.
+3. The previous point also applies to restoring local copies made
+   using ``pgclone copy``. See :ref:`Local Copies <local_copies>` for more
+   information.
 
 By default, reversible restores are turned off. They can be globally
 enabled with ``settings.PGCLONE_REVERSIBLE`` or overridden on
@@ -31,8 +32,8 @@ a per-configuration basis with the ``reversible`` key.
 
 .. tip::
 
-    Restoring to ``:current`` or ``:previous`` with
+    Restoring to ``:pre`` or ``:post`` with
     the ``--reversible`` flag is much faster than
-    restoring from a dump key. Restoring without ``--reversible`` is even
-    faster since databases are only renamed, but you lose
-    the ability to revert again.
+    restoring from a dump key. Keep this in mind if you are frequently needing
+    to restore back to these points in time, such as testing migrations or
+    having a clean slate for acceptance testing.

--- a/pgclone/copy_cmd.py
+++ b/pgclone/copy_cmd.py
@@ -10,17 +10,14 @@ def _copy(*, dump_key, database):
 
     source_db = db.conf(using=database)
 
-    if not dump_key or dump_key == ":current":
-        dump_key = ":current"
-        target_db_name = f'{source_db["NAME"]}__curr'
-    elif dump_key == ":previous":
-        target_db_name = f'{source_db["NAME"]}__prev'
-    else:
-        if not dump_key.startswith(":"):  # pragma: no cover
-            raise RuntimeError('Copy target must start with ":"')
+    if not dump_key.startswith(":"):  # pragma: no cover
+        raise exceptions.ValueError('Copy target must start with ":"')
+    elif dump_key in (":pre", ":post"):  # pragma: no cover
+        raise exceptions.ValueError(
+            ":pre and :post are reserved names. Please use a different copy target name."
+        )
 
-        target_db_name = dump_key[1:]
-
+    target_db_name = dump_key[1:]
     target_db = db.make(target_db_name, using=database, check=False)
 
     if source_db == target_db:  # pragma: no cover
@@ -29,15 +26,14 @@ def _copy(*, dump_key, database):
     logging.success_msg("Creating copy")
     db.drop(target_db, using=database)
     copy_db_sql = f'CREATE DATABASE "{target_db["NAME"]}" WITH TEMPLATE "{source_db["NAME"]}"'
-    db.kill_connections(source_db, using=database)
-    db.psql(copy_db_sql, using=database)
+    db.psql(copy_db_sql, using=database, kill_connections=source_db)
 
     logging.success_msg(f'Successfully copied database "{database}" to "{dump_key}"')
 
     return dump_key
 
 
-def copy(dump_key=None, *, database=None, config=None):
+def copy(dump_key, *, database=None, config=None):
     """
     Copies a database using ``CREATE DATABASE <dump_key> TEMPLATE <database>``.
 
@@ -46,9 +42,8 @@ def copy(dump_key=None, *, database=None, config=None):
     means the dump keys are always the database name prefixed with ``:``.
 
     Args:
-        dump_key (str, default=None): A name to use for the copy. Must be prefixed
+        dump_key (str): A name to use for the copy. Must be prefixed
             with ``:`` and only consist of valid database name characters.
-            If ``None``, ``:{database}__curr`` is used as the key.
         database (str, default=None): The database to copy.
         config (str, default=None): The configuration name
             from ``settings.PGCLONE_CONFIGS``.

--- a/pgclone/management/commands/pgclone.py
+++ b/pgclone/management/commands/pgclone.py
@@ -154,7 +154,7 @@ class RestoreCommand(BaseSubcommand):
             "--reversible",
             default=None,  # Use None so that configs/settings can be used as defaults
             action="store_true",
-            help="Keep current and previous database copies available for reversion.",
+            help="Keep pre/post restore database copies available for reversion.",
         )
         parser.add_argument(
             "-d",
@@ -185,11 +185,14 @@ class RestoreCommand(BaseSubcommand):
 
 class CopyCommand(BaseSubcommand):
     def add_arguments(self, parser):
-        parser.add_argument("dump_key", nargs="?", help="The local dump key to copy to.")
+        parser.add_argument(
+            "dump_key",
+            help="The database target in the format of a local dump key, e.g. ':db_backup'",
+        )
         parser.add_argument(
             "-d",
             "--database",
-            help="Restore to this database.",
+            help="Copy this database.",
         )
         parser.add_argument(
             "-c",


### PR DESCRIPTION
Using the ``--reversible`` option for ``pgclone restore`` is now only applicable to database dumps and no longer has any effect when executed against a local database. The aliases used by reversible restores have also changed from ``previous`` and ``current`` to ``pre`` and ``post``.

In other words, if one uses ``--reversible`` during a ``pgclone restore`` of a database dump, one can revert back to the version of data pre-restore using ``pgclone restore :pre`` or the version of the data immediately after the restore using ``pgclone restore :post``.

Unlike before, running ``pgclone restore :pre`` or ``pgclone restore :post`` has no effect on the copies created when restoring a dump using ``--reversible``. The ``:pre`` and ``:post`` aliases are only changed when a new reversible dump is restored.

This same behavior applies to local copies too. ``pclone copy`` now requires a target name in the format of a local dump key (``:db_name``), and the special ``:pre`` and ``:post`` aliases cannot be used. Users can do ``pgclone copy :my_backup`` and ``pgclone restore :my_backup`` without affecting the special snapshots related to the last restore from a dump.

Type: api-break